### PR TITLE
Add support for time domain cubification

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Install from PyPI (stable):
 pip install fitscube
 ```
 
-Or, onstall from this git repo (latest):
+Or, install from this git repo (latest):
 
 ```bash
 pip install git+https://github.com/AlecThomson/fitscube.git
@@ -91,14 +91,15 @@ options:
   -h, --help            show this help message and exit
   -o, --overwrite       Overwrite output file if it exists
   --create-blanks       Try to create a blank cube with evenly spaced frequencies
-  --freq-file FREQ_FILE
-                        File containing frequencies in Hz
-  --freqs FREQS [FREQS ...]
-                        List of frequencies in Hz
-  --ignore-freq         Ignore frequency information and just stack (probably not what you want)
+  --spec-file SPEC_FILE
+                        File containing frequencies in Hz or times in MJD s (if --time-domain == True)
+  --specs SPECS [SPECS ...]
+                        List of spequencies in Hz or MJD s
+  --ignore-spec         Ignore frequency or time information and just stack (probably not what you want)
   -v, --verbosity       Increase output verbosity
   --max-workers MAX_WORKERS
                         Maximum number of workers to use for concurrent processing
+  --time-domain         Flag for constructing a time-domain cube
 ```
 
 Python:

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -720,8 +720,8 @@ def cli() -> None:
     # Add options for specifying frequencies
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
-        "--freq-file",
-        help="File containing frequencies in Hz",
+        "--spec-file",
+        help="File containing frequencies in Hz or times in MJD s (if --time-domain == True)",
         type=Path,
         default=None,
     )

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -319,7 +319,7 @@ async def create_output_cube_coro(
 create_output_cube = sync_wrapper(create_output_cube_coro)
 
 
-def UTC_to_MJDsec(utc_time: str) -> float:
+def utc_to_mjdsec(utc_time: str) -> float:
     """
     convert UTC time (in isot format as found in fits header)
     to MJD seconds to shunt into a freq
@@ -346,7 +346,7 @@ async def read_spec_from_header_coro(
         try:
             spec = await asyncio.to_thread(header.get, QUANTITY)
             if time_domain_mode:
-                spec = UTC_to_MJDsec(spec)
+                spec = utc_to_mjdsec(spec)
             return spec * unit
         except KeyError as e:
             msg = "REFFREQ or DATE-OBS not in header. Cannot combine 2D images without spequency information."
@@ -357,7 +357,7 @@ async def read_spec_from_header_coro(
         wcs = WCS(header)
         if time_domain_mode:
             spec = await asyncio.to_thread(header.get, QUANTITY)
-            spec = UTC_to_MJDsec(spec)
+            spec = utc_to_mjdsec(spec)
             return spec * unit
 
         return wcs.spectral.pixel_to_world(0).to(u.Hz)

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -7,6 +7,7 @@ Assumes:
 - Frequency is either a WCS axis or in the REFFREQ header keyword
 - All the relevant information is in the first header of the first image
 
+Note: spequency = generic term for time or frequency
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ import astropy.units as u
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
+from astropy.time import Time
 from astropy.wcs import WCS
 from numpy.typing import ArrayLike
 from radio_beam import Beam, Beams
@@ -49,32 +51,32 @@ class InitResult(NamedTuple):
 
     header: fits.Header
     """Output header"""
-    freq_idx: int
-    """Index of frequency axis"""
-    freq_fits_idx: int
-    """FITS index of frequency axis"""
+    spec_idx: int
+    """Index of spequency axis"""
+    spec_fits_idx: int
+    """FITS index of spequency axis"""
     is_2d: bool
     """Whether the input is 2D"""
 
 
-class FrequencyInfo(NamedTuple):
-    """Frequency information."""
+class SpequencyInfo(NamedTuple):
+    """Frequency/time information."""
 
-    freqs: u.Quantity
-    """Frequencies"""
+    specs: u.Quantity
+    """Spequencies"""
     missing_chan_idx: ArrayLike
     """Missing channel indices"""
 
 
-class FileFrequencyInfo(NamedTuple):
-    """File frequency information."""
+class FileSpequencyInfo(NamedTuple):
+    """File frequency/time information."""
 
-    file_freqs: u.Quantity
-    """Frequencies matching each file"""
-    freqs: u.Quantity
-    """Frequencies"""
+    file_specs: u.Quantity
+    """Frequencies or times matching each file"""
+    specs: u.Quantity
+    """Spequencies"""
     missing_chan_idx: ArrayLike
-    """Missing channel indices"""
+    """Missing channel/time indices"""
 
 
 async def write_channel_to_cube_coro(
@@ -98,7 +100,9 @@ def np_arange_fix(start: float, stop: float, step: float) -> ArrayLike:
     return np.arange(start, stop, step)
 
 
-def isin_close(element: ArrayLike, test_element: ArrayLike) -> ArrayLike:
+def isin_close(
+    element: ArrayLike, test_element: ArrayLike, time_domain_mode: bool = False
+) -> ArrayLike:
     """Check if element is in test_element, within a tolerance.
 
     Args:
@@ -108,26 +112,35 @@ def isin_close(element: ArrayLike, test_element: ArrayLike) -> ArrayLike:
     Returns:
         ArrayLike: Boolean array
     """
-    return np.isclose(element[:, None], test_element).any(1)
+    if time_domain_mode:
+        # the following should be sufficient to test integration times to ~5ms accuracy
+        rtol = 1e-10
+        atol = 1e-9
+    else:
+        # defaults for np.isclose
+        rtol = 1e-5
+        atol = 1e-9
+    return np.isclose(element[:, None], test_element, atol, rtol).any(1)
 
 
-def even_spacing(freqs: u.Quantity) -> FrequencyInfo:
-    """Make the frequencies evenly spaced.
+def even_spacing(specs: u.Quantity, time_domain_mode: bool = False) -> SpequencyInfo:
+    """Make the spequencies evenly spaced.
 
     Args:
-        freqs (u.Quantity): Original frequencies
+        specs (u.Quantity): Original specuencies
 
     Returns:
-        FrequencyInfo: freqs, missing_chan_idx
+        SpequencyInfo: specs, missing_chan_idx
     """
-    freqs_arr = freqs.value.astype(np.longdouble)
-    diffs = np.diff(freqs_arr)
+    specs_arr = specs.value.astype(np.longdouble)
+    diffs = np.diff(specs_arr)
     min_diff: float = np.min(diffs)
     # Create a new array with the minimum difference
-    new_freqs = np_arange_fix(freqs_arr[0], freqs_arr[-1], min_diff)
-    missing_chan_idx = np.logical_not(isin_close(new_freqs, freqs_arr))
-
-    return FrequencyInfo(new_freqs * freqs.unit, missing_chan_idx)
+    new_specs = np_arange_fix(specs_arr[0], specs_arr[-1], min_diff)
+    missing_chan_idx = np.logical_not(
+        isin_close(new_specs, specs_arr, time_domain_mode)
+    )
+    return SpequencyInfo(new_specs * specs.unit, missing_chan_idx)
 
 
 async def create_cube_from_scratch_coro(
@@ -209,11 +222,12 @@ async def create_cube_from_scratch_coro(
 async def create_output_cube_coro(
     old_name: Path,
     out_cube: Path,
-    freqs: u.Quantity,
-    ignore_freq: bool = False,
+    specs: u.Quantity,
+    ignore_spec: bool = False,
     has_beams: bool = False,
     single_beam: bool = False,
     overwrite: bool = False,
+    time_domain_mode: bool = False,
 ) -> InitResult:
     """Initialize the data cube.
 
@@ -226,14 +240,19 @@ async def create_output_cube_coro(
         ValueError: If not 2D and FREQ is not in header
 
     Returns:
-        InitResult: header, freq_idx, freq_fits_idx, is_2d
+        InitResult: header, spec_idx, spec_fits_idx, is_2d
     """
-    old_data, old_header = fits.getdata(old_name, header=True, memmap=True)
-    even_freq = np.diff(freqs).std() < (1e-4 * u.Hz)
-    if not even_freq:
-        logger.warning("Frequencies are not evenly spaced")
 
-    n_chan = len(freqs)
+    # define units if in time or freq domain
+    unit = u.s if time_domain_mode else u.Hz
+    CTYPE = "TIME" if time_domain_mode else "FREQ"
+
+    old_data, old_header = fits.getdata(old_name, header=True, memmap=True)
+    even_spec = np.diff(specs).std() < (1e-4 * unit)
+    if not even_spec:
+        logger.warning("Spequencies are not evenly spaced")
+
+    n_chan = len(specs)
 
     is_2d = len(old_data.shape) == 2
     idx = 0
@@ -243,23 +262,25 @@ async def create_output_cube_coro(
         wcs = WCS(old_header)
         # Look for the frequency axis in wcs
         try:
-            idx = wcs.axis_type_names[::-1].index("FREQ")
+            idx = wcs.axis_type_names[::-1].index(CTYPE)
+
         except ValueError as e:
-            msg = "No FREQ axis found in WCS."
+            msg = f"No {CTYPE} axis found in WCS."
+
             raise ValueError(msg) from e
-        fits_idx = wcs.axis_type_names.index("FREQ") + 1
-        logger.info("FREQ axis found at index %s (NAXIS%s)", idx, fits_idx)
+        fits_idx = wcs.axis_type_names.index(CTYPE) + 1
+        logger.info(f"{CTYPE} axis found at index %s (NAXIS%s)", idx, fits_idx)
 
     new_header = old_header.copy()
     new_header["NAXIS"] = 3 if is_2d else len(old_data.shape)
     new_header[f"NAXIS{fits_idx}"] = n_chan
     new_header[f"CRPIX{fits_idx}"] = 1
-    new_header[f"CRVAL{fits_idx}"] = freqs[0].value
-    new_header[f"CDELT{fits_idx}"] = np.diff(freqs).mean().value
-    new_header[f"CUNIT{fits_idx}"] = "Hz"
-    new_header[f"CTYPE{fits_idx}"] = "FREQ"
+    new_header[f"CRVAL{fits_idx}"] = specs[0].value
+    new_header[f"CDELT{fits_idx}"] = np.median(np.diff(specs)).value
+    new_header[f"CUNIT{fits_idx}"] = f"{unit:fits}"
+    new_header[f"CTYPE{fits_idx}"] = CTYPE
 
-    if ignore_freq or not even_freq:
+    if ignore_spec or not even_spec:
         new_header[f"CDELT{fits_idx}"] = 1
         del new_header[f"CUNIT{fits_idx}"]
         new_header[f"CTYPE{fits_idx}"] = "CHAN"
@@ -277,6 +298,9 @@ async def create_output_cube_coro(
         )
         del new_header["BMAJ"], new_header["BMIN"], new_header["BPA"]
 
+    if time_domain_mode:
+        new_header["COMMENT"] = "The frequency/chan axis in this cube represents TIME."
+
     plane_shape = list(old_data.shape)
     cube_shape = plane_shape.copy()
     if is_2d:
@@ -288,117 +312,144 @@ async def create_output_cube_coro(
         output_file=out_cube, output_header=new_header, overwrite=overwrite
     )
     return InitResult(
-        header=output_header, freq_idx=idx, freq_fits_idx=fits_idx, is_2d=is_2d
+        header=output_header, spec_idx=idx, spec_fits_idx=fits_idx, is_2d=is_2d
     )
 
 
 create_output_cube = sync_wrapper(create_output_cube_coro)
 
 
-async def read_freq_from_header_coro(
+def UTC_to_MJDsec(utc_time: str) -> float:
+    """
+    convert UTC time (in isot format as found in fits header)
+    to MJD seconds to shunt into a freq
+    """
+    # logger.info(f"UTC time is {utc_time}")
+    secperday = 86400.0
+    return float((Time(utc_time, format="isot")).mjd) * secperday
+
+
+async def read_spec_from_header_coro(
     image_path: Path,
+    time_domain_mode: bool = False,
 ) -> u.Quantity:
     header = await asyncio.to_thread(fits.getheader, image_path)
     wcs = WCS(header)
     array_shape = wcs.array_shape
+    unit = u.s if time_domain_mode else u.Hz
+    QUANTITY = "DATE-OBS" if time_domain_mode else "REFFREQ"
     if array_shape is None:
         msg = "WCS does not have an array shape"
         raise ValueError(msg)
     is_2d = len(array_shape) == 2
     if is_2d:
         try:
-            freq = await asyncio.to_thread(header.get, "REFFREQ")
-            return freq * u.Hz
+            spec = await asyncio.to_thread(header.get, QUANTITY)
+            if time_domain_mode:
+                spec = UTC_to_MJDsec(spec)
+            return spec * unit
         except KeyError as e:
-            msg = "REFFREQ not in header. Cannot combine 2D images without frequency information."
+            msg = "REFFREQ or DATE-OBS not in header. Cannot combine 2D images without spequency information."
             raise KeyError(msg) from e
     try:
         if "SPECSYS" not in header:
             header["SPECSYS"] = "TOPOCENT"
         wcs = WCS(header)
+        if time_domain_mode:
+            spec = await asyncio.to_thread(header.get, QUANTITY)
+            spec = UTC_to_MJDsec(spec)
+            return spec * unit
+
         return wcs.spectral.pixel_to_world(0).to(u.Hz)
     except Exception as e:
         msg = "No FREQ axis found in WCS. Cannot combine N-D images without frequency information."
         raise ValueError(msg) from e
 
 
-read_freq_from_header = sync_wrapper(read_freq_from_header_coro)
+read_spec_from_header = sync_wrapper(read_spec_from_header_coro)
 
 
-async def parse_freqs_coro(
+async def parse_specs_coro(
     file_list: list[Path],
-    freq_file: Path | None = None,
-    freq_list: list[float] | None = None,
-    ignore_freq: bool = False,
+    spec_file: Path | None = None,
+    spec_list: list[float] | None = None,
+    ignore_spec: bool = False,
     create_blanks: bool = False,
-) -> FileFrequencyInfo:
+    time_domain_mode: bool = False,
+) -> FileSpequencyInfo:
     """Parse the frequency information.
 
     Args:
         file_list (list[str]): List of FITS files
-        freq_file (str | None, optional): File containing frequnecies. Defaults to None.
-        freq_list (list[float] | None, optional): List of frequencies. Defaults to None.
-        ignore_freq (bool | None, optional): Ignore frequency information. Defaults to False.
+        spec_file (str | None, optional): File containing spequnecies. Defaults to None.
+        spec_list (list[float] | None, optional): List of spequencies. Defaults to None.
+        ignore_spec (bool | None, optional): Ignore spequency information. Defaults to False.
 
     Raises:
-        ValueError: If both freq_file and freq_list are specified
-        KeyError: If 2D and REFFREQ is not in header
-        ValueError: If not 2D and FREQ is not in header
+        ValueError: If both spec_file and spec_list are specified
+        KeyError: If 2D and (REFFREQ or DATE-OBS)  is not in header
+         ValueError: If not 2D and FREQ is not in header
 
     Returns:
-        FileFrequencyInfo: file_freqs, freqs, missing_chan_idx
+        FileSpequencyInfo: file_specs, specs, missing_chan_idx
     """
-    if ignore_freq:
+    unit = u.s if time_domain_mode else u.Hz
+    if ignore_spec:
         logger.info("Ignoring frequency information")
-        return FileFrequencyInfo(
-            file_freqs=np.arange(len(file_list)) * u.Hz,
-            freqs=np.arange(len(file_list)) * u.Hz,
+        return FileSpequencyInfo(
+            file_specs=np.arange(len(file_list)) * unit,
+            specs=np.arange(len(file_list)) * unit,
             missing_chan_idx=np.zeros(len(file_list)).astype(bool),
         )
 
-    if freq_file is not None and freq_list is not None:
-        msg = "Must specify either freq_file or freq_list, not both"
+    if spec_file is not None and spec_list is not None:
+        msg = "Must specify either spec_file or spec_list, not both"
         raise ValueError(msg)
 
-    if freq_file is not None:
-        logger.info("Reading frequencies from %s", freq_file)
-        file_freqs = np.loadtxt(freq_file) * u.Hz
+    if spec_file is not None:
+        logger.info("Reading spequencies from %s", spec_file)
+        file_specs = np.loadtxt(spec_file) * unit
         assert (
-            len(file_freqs) == len(file_list)
-        ), f"Number of frequencies in {freq_file} ({len({file_freqs})}) does not match number of images ({len(file_list)})"
+            len(file_specs) == len(file_list)
+        ), f"Number of spequencies in {spec_file} ({len({file_specs})}) does not match number of images ({len(file_list)})"
         missing_chan_idx = np.zeros(len(file_list)).astype(bool)
 
     else:
-        logger.info("Reading frequencies from FITS files")
+        logger.info("Reading specuencies from FITS files")
         first_header = fits.getheader(file_list[0])
         if "SPECSYS" not in first_header:
             logger.warning("SPECSYS not in header(s). Will set to TOPOCENT")
-        # file_freqs = np.arange(len(file_list)) * u.Hz
+        # file_specs = np.arange(len(file_list)) * u.Hz
         missing_chan_idx = np.zeros(len(file_list)).astype(bool)
         coros = []
         for image_path in file_list:
-            coro = read_freq_from_header_coro(image_path)
+            coro = read_spec_from_header_coro(
+                image_path, time_domain_mode=time_domain_mode
+            )
             coros.append(coro)
 
-        list_of_freqs = await gather_with_limit(
-            None, *coros, desc="Extracting frequencies"
+        list_of_specs = await gather_with_limit(
+            None, *coros, desc="Extracting spequencies"
         )
-        file_freqs = np.array([f.to(u.Hz).value for f in list_of_freqs]) * u.Hz
 
-        freqs = file_freqs.copy()
+        file_specs = np.array([f.to(unit).value for f in list_of_specs]) * unit
+
+        specs = file_specs.copy()
 
     if create_blanks:
-        logger.info("Trying to create a blank cube with evenly spaced frequencies")
-        freqs, missing_chan_idx = even_spacing(file_freqs)
+        logger.info("Trying to create a blank cube with evenly spaced spequencies")
+        specs, missing_chan_idx = even_spacing(
+            file_specs, time_domain_mode=time_domain_mode
+        )
 
-    return FileFrequencyInfo(
-        file_freqs=file_freqs,
-        freqs=freqs,
+    return FileSpequencyInfo(
+        file_specs=file_specs,
+        specs=specs,
         missing_chan_idx=missing_chan_idx,
     )
 
 
-parse_freqs = sync_wrapper(parse_freqs_coro)
+parse_specs = sync_wrapper(parse_specs_coro)
 
 
 def parse_beams(
@@ -527,33 +578,37 @@ async def process_channel(
 async def combine_fits_coro(
     file_list: list[Path],
     out_cube: Path,
-    freq_file: Path | None = None,
-    freq_list: list[float] | None = None,
-    ignore_freq: bool = False,
+    spec_file: Path | None = None,
+    spec_list: list[float] | None = None,
+    ignore_spec: bool = False,
     create_blanks: bool = False,
     overwrite: bool = False,
     max_workers: int | None = None,
+    time_domain_mode: bool = False,
 ) -> u.Quantity:
     """Combine FITS files into a cube.
+    Can handle either frequency or time dimensions generically
+    we term the generic dimension spequency and refer to it as spec
 
     Args:
-        file_list (list[Path]): List of FITS files to combine
-        freq_file (Path | None, optional): Frequency file. Defaults to None.
-        freq_list (list[float] | None, optional): List of frequencies. Defaults to None.
-        ignore_freq (bool, optional): Ignore frequency information. Defaults to False.
-        create_blanks (bool, optional): Attempt to create even frequency spacing. Defaults to False.
+        spec_file (Path | None, optional): Spequency file. Defaults to None.
+        spec_list (list[float] | None, optional): List of spequencies. Defaults to None.
+        ignore_spec (bool, optional): Ignore spequency information. Defaults to False.
+         create_blanks (bool, optional): Attempt to create even frequency spacing. Defaults to False.
+        time_domain_mode (bool, optional): Work in time domain mode - make a time-cube. Default = False.
 
     Returns:
         tuple[fits.HDUList, u.Quantity]: The combined FITS cube and frequencies
     """
     # TODO: Check that all files have the same WCS
 
-    file_freqs, freqs, missing_chan_idx = await parse_freqs_coro(
-        freq_file=freq_file,
-        freq_list=freq_list,
-        ignore_freq=ignore_freq,
+    file_specs, specs, missing_chan_idx = await parse_specs_coro(
+        spec_file=spec_file,
+        spec_list=spec_list,
+        ignore_spec=ignore_spec,
         file_list=file_list,
         create_blanks=create_blanks,
+        time_domain_mode=time_domain_mode,
     )
     has_beams = "BMAJ" in fits.getheader(file_list[0])
     if has_beams:
@@ -567,26 +622,27 @@ async def combine_fits_coro(
         beams = None
         single_beam = False
 
-    # Sort the files by frequency
-    old_sort_idx = np.argsort(file_freqs)
+    # Sort the files by spequency
+    old_sort_idx = np.argsort(file_specs)
     file_list = np.array(file_list)[old_sort_idx].tolist()
-    new_sort_idx = np.argsort(freqs)
-    freqs = freqs[new_sort_idx]
+    new_sort_idx = np.argsort(specs)
+    specs = specs[new_sort_idx]
     missing_chan_idx = missing_chan_idx[new_sort_idx]
 
     # Initialize the data cube
     new_header, _, _, _ = await create_output_cube_coro(
         old_name=file_list[0],
         out_cube=out_cube,
-        freqs=freqs,
-        ignore_freq=ignore_freq,
+        specs=specs,
+        ignore_spec=ignore_spec,
         has_beams=has_beams,
         single_beam=single_beam,
         overwrite=overwrite,
+        time_domain_mode=time_domain_mode,
     )
 
-    new_channels = np.arange(len(freqs))
-    old_channels = np.arange(len(file_freqs))
+    new_channels = np.arange(len(specs))
+    old_channels = np.arange(len(file_specs))
 
     new_to_old = dict(zip(new_channels[np.logical_not(missing_chan_idx)], old_channels))
 
@@ -594,6 +650,9 @@ async def combine_fits_coro(
     with out_cube.open("rb+") as file_handle:
         for new_channel in new_channels:
             is_missing = missing_chan_idx[new_channel]
+            logger.info(
+                f"Channel {new_channel} missing == {missing_chan_idx[new_channel]}"
+            )
             old_channel = new_to_old.get(new_channel)
             if is_missing:
                 old_channel = 0
@@ -625,7 +684,7 @@ async def combine_fits_coro(
             header=beam_table_hdu.header,
         )
 
-    return freqs
+    return specs
 
 
 combine_fits = sync_wrapper(combine_fits_coro)
@@ -637,7 +696,7 @@ def cli() -> None:
     parser.add_argument(
         "file_list",
         nargs="+",
-        help="List of FITS files to combine (in frequency order)",
+        help="List of FITS files to combine (in frequency or time order)",
         type=Path,
     )
     parser.add_argument("out_cube", help="Output FITS file", type=Path)
@@ -652,6 +711,12 @@ def cli() -> None:
         action="store_true",
         help="Try to create a blank cube with evenly spaced frequencies",
     )
+    parser.add_argument(
+        "--time-domain",
+        action="store_true",
+        help="Flag for constructing a time-domain cube",
+        default=False,
+    )
     # Add options for specifying frequencies
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -661,16 +726,16 @@ def cli() -> None:
         default=None,
     )
     group.add_argument(
-        "--freqs",
+        "--specs",
         nargs="+",
-        help="List of frequencies in Hz",
+        help="List of spequencies in Hz or s",
         type=float,
         default=None,
     )
     group.add_argument(
-        "--ignore-freq",
+        "--ignore-spec",
         action="store_true",
-        help="Ignore frequency information and just stack (probably not what you want)",
+        help="Ignore frequency or time information and just stack (probably not what you want)",
     )
     parser.add_argument(
         "-v", "--verbosity", default=0, action="count", help="Increase output verbosity"
@@ -688,32 +753,37 @@ def cli() -> None:
     )
     overwrite = bool(args.overwrite)
     out_cube = Path(args.out_cube)
+    time_domain_mode = bool(args.time_domain)
     if not overwrite and out_cube.exists():
         msg = f"Output file {out_cube} already exists. Use --overwrite to overwrite."
         raise FileExistsError(msg)
 
-    freqs_file = out_cube.with_suffix(".freqs_Hz.txt")
-    if freqs_file.exists() and not overwrite:
-        msg = f"Output file {freqs_file} already exists. Use --overwrite to overwrite."
+    output_unit = u.s if time_domain_mode else u.Hz
+
+    specs_file = out_cube.with_suffix(f".specs_{output_unit:fits}.txt")
+
+    if specs_file.exists() and not overwrite:
+        msg = f"Output file {specs_file} already exists. Use --overwrite to overwrite."
         raise FileExistsError(msg)
 
     if overwrite:
         logger.info("Overwriting output files")
 
-    freqs = combine_fits(
+    specs = combine_fits(
         file_list=args.file_list,
         out_cube=out_cube,
-        freq_file=args.freq_file,
-        freq_list=args.freqs,
-        ignore_freq=args.ignore_freq,
+        spec_file=args.spec_file,
+        spec_list=args.specs,
+        ignore_spec=args.ignore_spec,
         create_blanks=args.create_blanks,
         overwrite=overwrite,
         max_workers=args.max_workers,
+        time_domain_mode=time_domain_mode,
     )
 
     logger.info("Written cube to %s", out_cube)
-    np.savetxt(freqs_file, freqs.to(u.Hz).value)
-    logger.info("Written frequencies to %s", freqs_file)
+    np.savetxt(specs_file, specs.to(output_unit).value)
+    logger.info("Written spequencies to %s", specs_file)
 
 
 if __name__ == "__main__":

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -6,16 +6,21 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.time import Time
 from fitscube.combine_fits import combine_fits, parse_specs
 
 
 @pytest.fixture()
 def even_specs() -> u.Quantity:
     rng = np.random.default_rng()
-    start = rng.integers(1, 3)
-    end = rng.integers(4, 6)
+    # mjd 60000 to 60000.2
+    start = rng.integers(5184000000, 5184017280)
+    end = rng.integers(5184025920, 5184043200)
+    # start = rng.integers(0, 17280)
+    # end = rng.integers(25920, 43200)
     num = rng.integers(6, 10)
-    return np.linspace(start, end, num) * u.GHz
+    # num=6
+    return np.linspace(start, end, num) * u.s
 
 
 @pytest.fixture()
@@ -29,11 +34,13 @@ def file_list(even_specs: u.Quantity):
     image = np.ones((1, 10, 10))
     for i, spec in enumerate(even_specs):
         header = fits.Header()
-        header["CRVAL3"] = spec.to(u.Hz).value
-        header["CDELT3"] = 1e8
+        header["CRVAL3"] = spec.to(u.s).value
+        header["CDELT3"] = 9.98
         header["CRPIX3"] = 1
-        header["CTYPE3"] = "FREQ"
-        header["CUNIT3"] = "Hz"
+        header["CTYPE3"] = "TIME"
+        header["CUNIT3"] = "s"
+        header["DATE-OBS"] = Time(spec.to(u.d).value, format="mjd").isot
+        header["MJD-OBS"] = Time(spec.to(u.d).value, format="mjd").mjd
         hdu = fits.PrimaryHDU(image * i, header=header)
         hdu.writeto(f"plane_{i}.fits", overwrite=True)
 
@@ -44,18 +51,24 @@ def file_list(even_specs: u.Quantity):
 
 
 def test_parse_specs(file_list: list[Path], even_specs: u.Quantity):
-    file_specs, specs, missing_chan_idx = parse_specs(file_list)
-    assert np.array_equal(file_specs, even_specs)
+    file_specs, specs, missing_chan_idx = parse_specs(file_list, time_domain_mode=True)
+    # assert np.array_equal(file_specs, even_specs)
+    assert np.allclose(file_specs, even_specs, rtol=1e-10, atol=1e-9)
 
 
 def test_uneven(file_list: list[Path], even_specs: u.Quantity):
-    unven_specs = np.concatenate([even_specs[0:1], even_specs[3:]])
+    uneven_specs = np.concatenate([even_specs[0:1], even_specs[3:]])
     file_array = np.array(file_list)
     uneven_files = np.concatenate([file_array[0:1], file_array[3:]]).tolist()
-    file_specs, specs, missing_chan_idx = parse_specs(uneven_files, create_blanks=True)
-    assert np.array_equal(file_specs, unven_specs)
+    file_specs, specs, missing_chan_idx = parse_specs(
+        uneven_files, create_blanks=True, time_domain_mode=True
+    )
+    assert np.allclose(file_specs, uneven_specs, rtol=1e-10, atol=1e-9)
+    # assert np.array_equal(file_specs, uneven_specs)
     assert missing_chan_idx[1]
-    assert np.allclose(specs.to(u.Hz).value, even_specs.to(u.Hz).value)
+    assert np.allclose(
+        specs.to(u.s).value, even_specs.to(u.s).value, rtol=1e-10, atol=1e-9
+    )
 
 
 def test_even_combine(file_list: list[Path], even_specs: u.Quantity, output_file: Path):
@@ -64,9 +77,10 @@ def test_even_combine(file_list: list[Path], even_specs: u.Quantity, output_file
         out_cube=output_file,
         create_blanks=False,
         overwrite=True,
+        time_domain_mode=True,
     )
 
-    assert np.array_equal(specs, even_specs)
+    assert np.allclose(specs, even_specs, rtol=1e-12, atol=1e-13)
 
     cube = fits.getdata(output_file, verify="exception")
     for chan in range(len(specs)):
@@ -78,7 +92,7 @@ def test_even_combine(file_list: list[Path], even_specs: u.Quantity, output_file
 def test_uneven_combine(
     file_list: list[Path], even_specs: u.Quantity, output_file: Path
 ):
-    # unven_specs = np.concatenate([even_specs[0:1], even_specs[3:]])
+    # uneven_specs = np.concatenate([even_specs[0:1], even_specs[3:]])
     file_array = np.array(file_list)
     uneven_files = np.concatenate([file_array[0:1], file_array[3:]]).tolist()
     specs = combine_fits(
@@ -86,9 +100,11 @@ def test_uneven_combine(
         out_cube=output_file,
         create_blanks=True,
         overwrite=True,
+        time_domain_mode=True,
     )
-
-    assert np.allclose(specs.to(u.Hz).value, even_specs.to(u.Hz).value)
+    print(specs)
+    print(even_specs)
+    assert np.allclose(specs.to(u.s).value, even_specs.to(u.s).value)
     expected_spectrum = np.arange(len(even_specs)).astype(float)
     expected_spectrum[1:3] = np.nan
 
@@ -100,7 +116,9 @@ def test_uneven_combine(
         if np.isnan(expected_spectrum[i]):
             assert np.isnan(cube_spectrum[i])
         else:
-            assert np.isclose(cube_spectrum[i], expected_spectrum[i])
+            assert np.isclose(
+                cube_spectrum[i], expected_spectrum[i]
+            )  # , atol=1e-11, rtol=1e-10)
     for chan in range(len(specs)):
         image = fits.getdata(file_list[chan], verify="exception")
         plane = cube[chan]


### PR DESCRIPTION
I've modified `combine_fits` to produce cubes along either time or frequency.
Have avoided duplication of functions and if-clauses where possible and have attempted to make the functions dimension-agnostic.
pytests are done under `tests/test_times.py` which is a re-jigging of `test_frequencies.py` for the time-domain.