### PR TITLE
Detect and add PC keys when combining and creating TIME axis

### DIFF
--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -163,9 +163,9 @@ async def create_cube_from_scratch_coro(
     try:
         output_wcs = WCS(output_header)
     except Exception as e:
-        logger.critical("Error creating new header")
+        logger.error("Error creating new header")
         for k in output_header:
-            logger.critical(f"{k} = {output_header[k]}")
+            logger.error(f"{k} = {output_header[k]}")
         raise e
     output_shape = output_wcs.array_shape
     msg = f"Creating a new FITS file with shape {output_shape}"
@@ -331,14 +331,11 @@ async def create_output_cube_coro(
         logger.debug(f"{key}={new_header[key]}")
 
     # Add extra transform fields for consistency
-    if ("PV1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
-        logger.info("Inserting PV fields into header")
-        pv1 = f"PC{fits_idx}_1"
+    if ("CD1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
+        transform_type = "CD" if "CD1_1" in new_header else "PC"
+        pv1 = f"{transform_type}{fits_idx}_{fits_idx}"
         logger.info(f"Adding {pv1} to header")
         new_header[pv1] = 1.0
-        pv2 = f"PC{fits_idx}_2"
-        logger.info(f"Adding {pv2} to header")
-        new_header[pv2] = 0.0
 
     if ignore_spec or not even_spec:
         logger.info(


### PR DESCRIPTION
An annoying bug was found when trying to co-add images where the FITS files had PC/PV keys. They were raising an error when a TIME axis was formed, as I was not also adding PV fields. 

This PR will search for either a PV1_1 field or a PC1_1 field. If detected, appropriate fields are added for the new TIME axis. 