### PR TITLE
Incorporate a bounding box derivation during fitscube construction

### DIFF
--- a/fitscube/bounding_box.py
+++ b/fitscube/bounding_box.py
@@ -1,0 +1,131 @@
+"""Some basic utilities to help with the creating of
+bounding boxes to use in fitscube"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+
+from fitscube.logging import logger
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """Simple container to represent a bounding box"""
+
+    xmin: int
+    """Minimum x pixel"""
+    xmax: int
+    """Maximum x pixel"""
+    ymin: int
+    """Minimum y pixel"""
+    ymax: int
+    """Maximum y pixel"""
+    original_shape: tuple[int, int]
+    """The original shape of the image. If constructed against a cube this is the shape of a single plane."""
+
+
+def create_bound_box_plane(image_data: np.ndarray) -> BoundingBox | None:
+    """Create a bounding box around pixels in a 2D image. If all
+    pixels are not valid, then ``None`` is returned.
+
+    Args:
+        image_data (np.ndarray): The 2D image to construct a bounding box around
+
+    Returns:
+        Optional[BoundingBox]: None if no valid pixels, a bounding box with the (xmin,xmax,ymin,ymax) of valid pixels
+    """
+    assert len(image_data.shape) == 2, (
+        f"Only two-dimensional arrays supported, received {image_data.shape}"
+    )
+
+    # First convert to a boolean array
+    image_valid = np.isfinite(image_data)
+
+    if not any(image_valid.reshape(-1)):
+        logger.info("No pixels to creating bounding box for")
+        return None
+
+    # Then make them 1D arrays
+    x_valid = np.any(image_valid, axis=1)
+    y_valid = np.any(image_valid, axis=0)
+
+    # Now get the first and last index
+    xmin, xmax = np.where(x_valid)[0][[0, -1]]
+    ymin, ymax = np.where(y_valid)[0][[0, -1]]
+
+    return BoundingBox(
+        xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax, original_shape=image_data.shape[-2:]
+    )
+
+
+def extract_common_bounding_box(bounding_boxes: list[BoundingBox, None]) -> BoundingBox:
+    """Get the smallest bounding box that encompasses all bounding boxes
+
+    Args:
+        bounding_boxes (list[BoundingBox, None]): A list of bounding boxes. If None (returned for invalid images) skip it.
+
+    Raises:
+        ValueError: If all input bounding boxes are invalid
+        ValueError: If there is an `original_shape` mismatch
+
+    Returns:
+        BoundingBox: The smallest bounding box
+    """
+
+    # Step 1: filter out all Nones
+    valid_boxes: list[BoundingBox] = [bb for bb in bounding_boxes if bb is not None]
+
+    if len(valid_boxes) == 0:
+        msg = "No valid input boxes to consider"
+        raise ValueError(msg)
+
+    if not all(
+        valid_boxes[0].original_shape == bb.original_shape for bb in valid_boxes
+    ):
+        msg = "Different shapes, and not sure this is really supported or meaningful"
+        raise ValueError(msg)
+
+    xmin = np.min(bb.xmin for bb in valid_boxes)
+    xmax = np.max(bb.xmin for bb in valid_boxes)
+    ymin = np.min(bb.ymin for bb in valid_boxes)
+    ymax = np.max(bb.ymin for bb in valid_boxes)
+
+    return BoundingBox(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
+
+
+def get_bounding_box_for_fits(
+    fits_path: Path, invalidate_zeros: bool = False
+) -> BoundingBox:
+    """Create a bounding box for an image contained in a FITS file.
+
+    The assumption is that the FITS file contains an image, not a cube.
+    If the cube can bot be reshapped to an image without losing data
+    the underlying bounding box creation will fail.
+
+    Args:
+        fits_path (Path): The fits image to call
+        invalidate_zeros (bool, optional): Mark pixels that are exactly 0.0 as invalid (NaN them). Defaults to False.
+
+    Returns:
+        BoundingBox: The bounding box that describes the bounds of valid data
+    """
+    data = fits.getdata(fits_path)
+    data = np.squeeze(data)
+
+    if invalidate_zeros:
+        data[data == 0.0] = np.nan
+
+    return create_bound_box_plane(image_data=data)
+
+
+async def get_bounding_box_for_image_coro(
+    fits_path: Path, invalidate_zeros: bool = False
+) -> BoundingBox:
+    """async version of get_bound"""
+    return get_bounding_box_for_fits(
+        fits_path=fits_path, invalidate_zeros=invalidate_zeros
+    )

--- a/fitscube/bounding_box.py
+++ b/fitscube/bounding_box.py
@@ -76,11 +76,13 @@ def create_bound_box_plane(image_data: np.ndarray) -> BoundingBox | None:
     )
 
 
-def extract_common_bounding_box(bounding_boxes: list[BoundingBox, None]) -> BoundingBox:
+def extract_common_bounding_box(
+    bounding_boxes: list[BoundingBox | None],
+) -> BoundingBox:
     """Get the smallest bounding box that encompasses all bounding boxes
 
     Args:
-        bounding_boxes (list[BoundingBox, None]): A list of bounding boxes. If None (returned for invalid images) skip it.
+        bounding_boxes (list[BoundingBox | None]): A list of bounding boxes. If None (returned for invalid images) skip it.
 
     Raises:
         ValueError: If all input bounding boxes are invalid

--- a/fitscube/bounding_box.py
+++ b/fitscube/bounding_box.py
@@ -126,7 +126,7 @@ def extract_common_bounding_box(
 
 async def get_bounding_box_for_fits_coro(
     fits_path: Path, invalidate_zeros: bool = False
-) -> BoundingBox:
+) -> BoundingBox | None:
     """Create a bounding box for an image contained in a FITS file.
 
     The assumption is that the FITS file contains an image, not a cube.
@@ -138,7 +138,7 @@ async def get_bounding_box_for_fits_coro(
         invalidate_zeros (bool, optional): Mark pixels that are exactly 0.0 as invalid (NaN them). Defaults to False.
 
     Returns:
-        BoundingBox: The bounding box that describes the bounds of valid data
+        BoundingBox | None: The bounding box that describes the bounds of valid data. If all data are invalid (and not bounding box possible) None is returned.
     """
     data = await asyncio.to_thread(fits.getdata, fits_path, memmap=False)
     data = np.squeeze(data)

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -160,7 +160,13 @@ async def create_cube_from_scratch_coro(
     if output_file.exists() and overwrite:
         output_file.unlink()
 
-    output_wcs = WCS(output_header)
+    try:
+        output_wcs = WCS(output_header)
+    except Exception as e:
+        logger.critical("Error creating new header")
+        for k in output_header:
+            logger.critical(f"{k} = {output_header[k]}")
+        raise e
     output_shape = output_wcs.array_shape
     msg = f"Creating a new FITS file with shape {output_shape}"
     logger.info(msg)

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -324,6 +324,7 @@ async def create_output_cube_coro(
         key = f"{k}{fits_idx}"
         logger.debug(f"{key}={new_header[key]}")
 
+    # Add extra transform fields for consistency
     if ("PV1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
         logger.info("Inserting PV fields into header")
         pv1 = f"PC{fits_idx}_1"

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -324,6 +324,11 @@ async def create_output_cube_coro(
         key = f"{k}{fits_idx}"
         logger.debug(f"{key}={new_header[key]}")
 
+    if ("PV1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
+        logger.info("Inserting PV header")
+        new_header[f"PC{fits_idx}_1"] = 1.0
+        new_header[f"PC{fits_idx}_2"] = 0.0
+
     if ignore_spec or not even_spec:
         logger.info(
             f"Ignore the specrency information, {ignore_spec=} or {not even_spec=}"

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -325,9 +325,13 @@ async def create_output_cube_coro(
         logger.debug(f"{key}={new_header[key]}")
 
     if ("PV1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
-        logger.info("Inserting PV header")
-        new_header[f"PC{fits_idx}_1"] = 1.0
-        new_header[f"PC{fits_idx}_2"] = 0.0
+        logger.info("Inserting PV fields into header")
+        pv1 = f"PC{fits_idx}_1"
+        logger.info(f"Adding {pv1} to header")
+        new_header[pv1] = 1.0
+        pv2 = f"PC{fits_idx}_2"
+        logger.info(f"Adding {pv2} to header")
+        new_header[pv2] = 0.0
 
     if ignore_spec or not even_spec:
         logger.info(

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -168,15 +168,9 @@ async def create_cube_from_scratch_coro(
     try:
         output_wcs = WCS(output_header)
     except Exception as e:
-<<<<<<< HEAD
-        logger.critical("Error creating new header")
-        for k in output_header:
-            logger.critical(f"{k} = {output_header[k]}")
-=======
         logger.error("Error creating new header")
         for k in output_header:
             logger.error(f"{k} = {output_header[k]}")
->>>>>>> upstream/master
         raise e
     output_shape = output_wcs.array_shape
     msg = f"Creating a new FITS file with shape {output_shape}"
@@ -344,22 +338,11 @@ async def create_output_cube_coro(
         logger.debug(f"{key}={new_header[key]}")
 
     # Add extra transform fields for consistency
-<<<<<<< HEAD
-    if ("PV1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
-        logger.info("Inserting PV fields into header")
-        pv1 = f"PC{fits_idx}_1"
-        logger.info(f"Adding {pv1} to header")
-        new_header[pv1] = 1.0
-        pv2 = f"PC{fits_idx}_2"
-        logger.info(f"Adding {pv2} to header")
-        new_header[pv2] = 0.0
-=======
     if ("CD1_1" in new_header or "PC1_1" in new_header) and fits_idx != 1:
         transform_type = "CD" if "CD1_1" in new_header else "PC"
         pv1 = f"{transform_type}{fits_idx}_{fits_idx}"
         logger.info(f"Adding {pv1} to header")
         new_header[pv1] = 1.0
->>>>>>> upstream/master
 
     if ignore_spec or not even_spec:
         logger.info(
@@ -382,7 +365,6 @@ async def create_output_cube_coro(
         )
         del new_header["BMAJ"], new_header["BMIN"], new_header["BPA"]
 
-<<<<<<< HEAD
     if bounding_box:
         logger.info("Updating CRPIX1 and CRPIX2 header values to reflect bounding box")
         new_header["CRPIX1"] -= bounding_box.ymin
@@ -391,8 +373,6 @@ async def create_output_cube_coro(
         new_header["NAXIS1"] = bounding_box.y_span
         new_header["NAXIS2"] = bounding_box.x_span
 
-=======
->>>>>>> upstream/master
     plane_shape = list(old_data.shape)
     cube_shape = plane_shape.copy()
     if is_2d:

--- a/fitscube/combine_fits.py
+++ b/fitscube/combine_fits.py
@@ -361,9 +361,6 @@ async def create_output_cube_coro(
         )
         del new_header["BMAJ"], new_header["BMIN"], new_header["BPA"]
 
-    if time_domain_mode:
-        new_header["COMMENT"] = "The frequency/chan axis in this cube represents TIME."
-
     plane_shape = list(old_data.shape)
     cube_shape = plane_shape.copy()
     if is_2d:


### PR DESCRIPTION
In ASKAP land a lot of the linmos constructed images are excessively large, being padded with zeros. Thus, the output fitscube can be very large, where a lot of the space is comprised of some padded set of pixels. 

This PR attempts to minimise this size of the final output fits cube. It does this by making a first pass over all images where an a tight bounding box is constructed. These are pulled together to identify the final trimmed size. 

Once the final output size has been computed, the final header is updated and channels are trimmed as they are re-read in. 